### PR TITLE
[EN-6550] [PythonAPI] Change the installation instructions in the README.md

### DIFF
--- a/.github/workflows/publishpackage.yml
+++ b/.github/workflows/publishpackage.yml
@@ -11,37 +11,41 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        run: |
-          pip install poetry
-        shell: bash
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+
       - name: Set poetry env
         run: |
-          poetry config virtualenvs.create false
-          poetry install --no-root
+          pip install --upgrade pip
+          pip install taskipy cython toml
+          poetry install
         shell: bash
+
       - name: Create tarball
         if: matrix.python-version == 3.7
         run: |
-          task build -f sdist
+          poetry run build -f sdist
         shell: bash
+
       - name: Create wheel
         run: |
-          task build -f wheel
+          poetry run build -f wheel
         shell: bash
+
       - name: Upload artifacts
         if: success()
         uses: actions/upload-artifact@v2
@@ -51,26 +55,29 @@ jobs:
 
 
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - name: Install poetry
-        run: |
-          pip install poetry
-        shell: bash
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+
       - name: Clear dist folder
         run: |
           rm -rf dist/
+
       - name: Download
         uses: actions/download-artifact@v2
         with:
           name: artifacts
           path: dist/
+
       - name: Publish to PyPI
         if: success()
         run: |

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -9,68 +9,73 @@ jobs:
   installation:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root --no-dev
-        pip install taskipy cython
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install --only main
         task build -f sdist
         pip uninstall --yes taskipy cython
       shell: bash
+
     - name: Install package artifact
       run: |
         pip install dist/dxfeed*
         pip uninstall --yes dxfeed
       shell: bash
+
   tests:
     needs: installation
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install
       shell: bash
+
     - name: Run tests
       run: |
-        task test
+        poetry run task test
       shell: bash
+
     - name: Generate doc
+      if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
       run: |
-        task html_docs
+        poetry run task html_docs
       shell: bash
-      if: matrix.os == 'ubuntu-18.04' && matrix.python-version == 3.7

--- a/.github/workflows/testdevelop.yml
+++ b/.github/workflows/testdevelop.yml
@@ -12,68 +12,73 @@ jobs:
   installation:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root --no-dev
-        pip install taskipy cython
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install --only main
         task build -f sdist
         pip uninstall --yes taskipy cython
       shell: bash
+
     - name: Install package artifact
       run: |
         pip install dist/dxfeed*
         pip uninstall --yes dxfeed
       shell: bash
+
   tests:
     needs: installation
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install
       shell: bash
+
     - name: Run tests
       run: |
-        task test
+        poetry run task test
       shell: bash
+
     - name: Generate doc
+      if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
       run: |
-        task html_docs
+        poetry run task html_docs
       shell: bash
-      if: matrix.os == 'ubuntu-18.04' && matrix.python-version == 3.7

--- a/.github/workflows/testpackage.yml
+++ b/.github/workflows/testpackage.yml
@@ -13,68 +13,73 @@ jobs:
   installation:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root --no-dev
-        pip install taskipy cython
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install --only main
         task build -f sdist
         pip uninstall --yes taskipy cython
       shell: bash
+
     - name: Install package artifact
       run: |
         pip install dist/dxfeed*
         pip uninstall --yes dxfeed
       shell: bash
+
   tests:
     needs: installation
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        pip install poetry
-      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2
+
     - name: Set poetry env
       run: |
-        poetry config virtualenvs.create false
-        poetry install --no-root
+        pip install --upgrade pip
+        pip install taskipy cython toml
+        poetry install
       shell: bash
+
     - name: Run tests
       run: |
-        task test
+        poetry run task test
       shell: bash
+
     - name: Generate doc
+      if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.7
       run: |
-        task html_docs
+        poetry run task html_docs
       shell: bash
-      if: matrix.os == 'ubuntu-18.04' && matrix.python-version == 3.7

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 [![PyPI](https://img.shields.io/pypi/v/dxfeed)](https://pypi.org/project/dxfeed/)
 [![Documentation Status](https://readthedocs.org/projects/dxfeed/badge/?version=latest)](https://dxfeed.readthedocs.io/en/latest/?badge=latest)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dxfeed)](https://pypi.org/project/dxfeed/)
+![Platform](https://img.shields.io/badge/platform-win--x64%20%7C%20linux--x64%20%7C%20osx--x64-lightgrey)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/dxfeed)](https://pypi.org/project/dxfeed/)
 [![PyPI - License](https://img.shields.io/pypi/l/dxfeed)](https://github.com/dxFeed/dxfeed-python-api/blob/master/LICENSE)
 [![Test workflow](https://github.com/dxFeed/dxfeed-python-api/workflows/Test%20package/badge.svg)](https://github.com/dxFeed/dxfeed-python-api/actions)
 
+:warning:
+This library will be superseded by the Graal Python API based on [GraalVM](https://www.graalvm.org/latest/reference-manual/native-image/) 
+(similar to [Graal .NET API](https://github.com/dxFeed/dxfeed-graal-net-api#readme)).\
+The current implementation has a number of architectural limitations that will be fixed in the new one.\
+Please note that feature development has been completely halted in this version.
 
+</br>
 
 This package provides access to [dxFeed](https://www.dxfeed.com/) streaming data.
 The library is build as a thin wrapper over [dxFeed C-API library](https://github.com/dxFeed/dxfeed-c-api).
@@ -26,10 +33,46 @@ Package distribution: [pypi.org/project/dxfeed](https://pypi.org/project/dxfeed/
 
 **Requirements:** python >= 3.6
 
+On Linux, WSL and macOS, we recommend installing python via [pyenv](https://github.com/pyenv/pyenv):
+
+An example of how to install python on Ubuntu 20.04:
+
+```bash
+# Update the package index files on the system
+sudo apt-get update
+
+# Install pyenv dependencies
+sudo apt-get install make build-essential libssl-dev zlib1g-dev \
+libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+# Run automatic pyenv installer
+curl https://pyenv.run | bash
+
+# Configure bash shell
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+# Restart bash shell
+bash
+
+# Install python 3.9.16
+pyenv install 3.9.16
+
+# Set python 3.9.16 as global
+pyenv global 3.9.16
+
+# Check python version
+python --version
+#>>> Python 3.9.16
+
+```
+
 Install package via PyPI:
 
 ```python
-pip3 install dxfeed
+python -m pip install dxfeed
 ``` 
 
 ## Installation from sources
@@ -37,10 +80,15 @@ pip3 install dxfeed
 To install dxfeed from source you need Poetry. It provides a custom installer.
 This is the recommended way of installing poetry according to [documentation](https://python-poetry.org/docs/)
 
-For macOS / Linux / Windows (with bash):
+For macOS / Linux / Windows (WSL):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://install.python-poetry.org | python3 -
+```
+
+For Windows (Powershell):
+```powershell
+(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | py -
 ```
 
 In the project root directory (same one where you found this file after

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ toml = '^0.10.2'
 # Currently they have to be specified as non-dev dependencies with optional = true
 # Refer to: https://github.com/sdispater/poetry/issues/129
 # Issue to watch for: https://github.com/python-poetry/poetry/issues/1644
-jupyter = { version = '^1.0.0', optional = true }
+# Disable jupiter from pyproject.toml, because the `poetry install` is extremely with this dependency
+#jupyter = { version = '^1.0.0', optional = true }
 cython = { version = '^0.29.14', optional = true }
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**What was done**:
1) Fix the installation instructions in the README.md file (recommends using pyenv).
2) Fix the recommendation to install poetry.
3) Disable jupiter from pyproject.toml. Led to a very long installation (poetry install) time of ~20 minutes.
4) Fix github workflow (ubuntu 18.04 no longer available, some actions did not work, etc).
5) Remove Python 3.6 from github workflows (currently not working, need to fix it).